### PR TITLE
Add ABIDetect action for use against calamares libraries

### DIFF
--- a/abidetect/action.yml
+++ b/abidetect/action.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2021 Adriaan de Groot <groot@kde.org>
+
+name: 'ABI Detect'
+description: 'Detect changes in ABI'
+
+runs:
+  using: "composite"
+  steps:
+    - id: run-abicheck
+      shell: bash
+      run: |
+        ./ci/abicheck.sh


### PR DESCRIPTION
This is a pre-requisite for one of the ABI checks discussed in
https://github.com/calamares/calamares/pull/2002 to eventually be run
against the 3.3/calamares branches.

This seemed like a reasonable place to start after that discussion. I'd like to continue working on the CI push workflow and release script after this one.